### PR TITLE
Updated ProGet License Restrictions

### DIFF
--- a/ProGet/administration/license.htm
+++ b/ProGet/administration/license.htm
@@ -211,14 +211,6 @@
           </tr>
 
           <tr>
-              <th>Custom Licensing Agreement</th>
-              <td> </td>
-              <td>*</td>
-              <td>&#10004;</td>
-              <td>&#10004;</td>
-
-          </tr>
-          <tr>
               <th><a href="/support/documentation/proget/installation/load-balancing-and-automatic-failover" target="_blank">Load Balancing Support</a></th>
               <td></td>
               <td></td>


### PR DESCRIPTION
Removed the option for custom license agreements from the https://inedo.com/support/documentation/proget/administration/license page

Was requested by Scott

Tested locally and on .test