### PR TITLE
Update #.md

### DIFF
--- a/BuildMaster/builds/external-systems/#.md
+++ b/BuildMaster/builds/external-systems/#.md
@@ -46,7 +46,7 @@ You can create as many resource credentials as you need, at both the system- and
 
 A continuous integration can be configured to not only compile your application's source code and run automated tests against it, but to capture "artifacts" of that process. These artifacts typically include whatever files the compiler output, i.e. your compiled application.
 
-BuildMaster can automatically import these artifacts so you can deploy them as needed, as BuildMaster supports queuing in CI server tools like TeamCity. Once a build is queued, importing an artifact ensures BuildMaster will be able to deploy it to future stages whether the CI server is accessible or not. The relationship doesn't require active access from both.
+BuildMaster can automatically import these artifacts so you can deploy them as needed. This ensures that BuildMaster will be able to deploy it to future stages whether the CI server is accessible or not; in addition, the relationship doesn't require active access from both.
 
 Different types of operations are used to get artifacts from different CI servers and projects in those systems. For example, `Jenkins::Import-Artifact` is used to get artifacts from a build job on a Jenkins server, and `  TeamCity::Import-Artifact` is used for TeamCity.
 

--- a/BuildMaster/builds/external-systems/#.md
+++ b/BuildMaster/builds/external-systems/#.md
@@ -46,7 +46,7 @@ You can create as many resource credentials as you need, at both the system- and
 
 A continuous integration can be configured to not only compile your application's source code and run automated tests against it, but to capture "artifacts" of that process. These artifacts typically include whatever files the compiler output, i.e. your compiled application.
 
-BuildMaster can automatically import these artifacts so you can deploy them as needed.
+BuildMaster can automatically import these artifacts so you can deploy them as needed, as BuildMaster supports queuing in CI server tools like TeamCity. Once a build is queued, importing an artifact ensures BuildMaster will be able to deploy it to future stages whether the CI server is accessible or not. The relationship doesn't require active access from both.
 
 Different types of operations are used to get artifacts from different CI servers and projects in those systems. For example, `Jenkins::Import-Artifact` is used to get artifacts from a build job on a Jenkins server, and `  TeamCity::Import-Artifact` is used for TeamCity.
 


### PR DESCRIPTION
updated that one line about how, once you've queued something in the server, BuildMaster can still get at it even if TeamCity isn't acccessible