### PR TITLE
Fix typo for proget-api-assets-metadata-set.md

### DIFF
--- a/Content/proget/reference-api/proget-api-assets/metadata-endpoints/proget-api-assets-metadata-set.md
+++ b/Content/proget/reference-api/proget-api-assets/metadata-endpoints/proget-api-assets-metadata-set.md
@@ -14,7 +14,7 @@ pgutil assets metadata set custom --path=data-files/data.bin --feed=myAssetDirec
 :::
 
 ## Command Specification (CLI)
-The `assets metadata set` command is used to return metadata for the specified asset item.
+The `assets metadata set` command is used to write metadata for the specified asset item.
 
 There are two commands available (`custom`, and `cache`), and each command has options that correspond to fields in an asset's metadata. See [Custom Metadata](/docs/proget/asset-directories-file-storage/what-is-an-asset-directory#custom-metadata) to learn more. 
 


### PR DESCRIPTION
It looks like this was a copy-paste error from the get documentation page.