### PR TITLE
Migration docs final touches

### DIFF
--- a/Content/proget/installation/migrating-to-proget/proget-azure-devops-feed-migration.md
+++ b/Content/proget/installation/migrating-to-proget/proget-azure-devops-feed-migration.md
@@ -1,6 +1,7 @@
 ---
 title: "HOWTO: Migrate from Azure DevOps to ProGet"
 order: 2
+max-header-level: 3
 ---
 
 Migrating an Azure DevOps repository to ProGet can be done in a matter of minutes using ProGet’s Feed Importer feature. This feature allows packages from a remote feed to be downloaded to a local feed. 

--- a/Content/proget/installation/migrating-to-proget/proget-other-feed-migration.md
+++ b/Content/proget/installation/migrating-to-proget/proget-other-feed-migration.md
@@ -1,6 +1,7 @@
 ---
 title: "HOWTO: Migrate from Another Repository to ProGet"
 order: 5
+max-header-level: 3
 ---
 
 Migrating a repository to ProGet can be done in a matter of minutes using ProGet’s Feed Importer feature. This feature allows packages from a remote feed to be downloaded to a local feed. 

--- a/Content/proget/installation/migrating-to-proget/proget-sonatype-nexus-feed-migration.md
+++ b/Content/proget/installation/migrating-to-proget/proget-sonatype-nexus-feed-migration.md
@@ -8,10 +8,9 @@ Using ProGet’s Feed Importer feature, migrating a Sonatype Nexus repository to
 
 In this article, you’ll learn how to use ProGet’s Feed Importer feature to move packages from your Sonatype Nexus repositories to ProGet. 
 
-## Migrating Packages from Sonatype Nexus to ProGet
 Package migration is fast and straightforward, requiring only a few clicks and your Nexus URL and credentials.
 
-### Step 1: Create a New Feed
+## Step 1: Create a New Feed
 First, let’s set up a new feed where your packages will be imported. Go to “Feeds” and choose “Create New Feed” to begin.
 
 ![Create New Feed](/resources/docs/proget-feeds-createnewfeed.png){height="" width="50%"}
@@ -28,7 +27,7 @@ Then, enter a name for your feed. For this example, we’ll use “internal-nuge
 
 ![Name Feed](/resources/docs/proget-createfeed-name.png){height="" width="50%"}
 
-### Step 2: Connect to Sonatype Nexus
+## Step 2: Connect to Sonatype Nexus
 With the feed created, it’s time to connect to your Sonatype Nexus repository. In the `internal-nuget` feed, click the dropdown and select “Import Packages”.
 
 ![Sonatype Import](/resources/docs/proget-importpackages.png){height="" width="50%"}
@@ -41,7 +40,7 @@ Then, choose “Sonatype Nexus” to have ProGet configured to migrate your pack
 
 ![Sonatype](/resources/docs/proget-connectfeed-migrate-sonatype.png){height="" width="50%"}
 
-### Step 3: Migrate Your Packages
+## Step 3: Migrate Your Packages
 Now, enter your Nexus URL along with your credentials. 
 
 ![Sonatype Migrate](/resources/docs/proget-migrate-sonatype.png){height="" width="50%"}


### PR DESCRIPTION
Updated migration docs with final touches.

Changes from previous version:
- added max-level-header to "Migrate from Azure DevOps to ProGet" and "Migrate from Another Repository to ProGet" docs
- removed "Migrating Packages from Sonatype Nexus to ProGet" heading and changed "Step" headings from "###" to "##"