### PR TITLE
Edited Stopgap License Keys page to remove Inedo key.

### DIFF
--- a/Content/myinedo/stopgap-license-keys.md
+++ b/Content/myinedo/stopgap-license-keys.md
@@ -5,43 +5,34 @@ order: 7
 
 We aim to provide customers with self-service options through MyInedo for situations when a license key hasn't been renewed in time. Follow the steps below to generate a (temporary) stopgap license key and ensure your software service is uninterrupted.
 
-
 ## What is a Stopgap License?
 Stopgap license keys allow your team to continue working uninterrupted without a lapse in features/services.
 
 A stopgap license key may be necessary if:
-- Your license is expiring before your accounts payable team is able to create a PO
-- Your renewal contact left the company and their role wasn't updated
-- License expiry emails went unnoticed
+- Your license is expiring before your accounts payable team is able to create a PO.
+- Your renewal contact left the company and their role wasn't updated.
+- License expiry emails went unnoticed.
 
 Regardless of the reason, generating/requesting a stopgap license key is straightforward and quick. 
 
+If organizations are using enterprise functionality unavailable in the trail edition (i.e. ProGet's feed replication), or require more/servers (BuildMaster, Otter), this functionality can still be accessed with a self-generated trial stopgap license key.
+
 :::(Info) (License Key Expiration)
-Stopgap license keys do not extend the term of your paid license key. 
+Stopgap license keys do not extend the term of your paid license key.
 
 Example: If your license key normally lasts 12 months, after using your full stopgap license key for one month, your newly renewed paid license key would expire in 11 months.
 :::
 
-There are two ways to acquire a stopgap license key:
+## Self-Generated Stopgap License Key (Trial)
 
-## Self-Generated Stopgap License Key (Trial) 
-This is the best option for organizations that absolutely cannot have their license keys expire and cannot wait for customer support. This process takes under 10 minutes.
+A self-generated stopgap license key should be created when your organization absolutely cannot have their license keys expire and cannot wait for customer support. This process takes under 10 minutes.
 
 Go to your [MyInedo](https://my.inedo.com/){target="_blank"} portal and click on "Request Trial/Free License." There will be 2 options presented to you for every product: free and trial.
 
 ![Request License](/resources/docs/myinedo-licensekeys-requestkey.png){height="" width="50%"}
 
-Select the trial edition to get a key that will last 30 days; unlike the Free Edition, a Trial Key will have the standard paid features available. 
+Select the trial edition to get a key that will last 30 days; unlike the Free Edition, a Trial Key will have the standard paid features available.
 
 ![View License Key](/resources/docs/myinedo-licensekeys-viewkey.png){height="" width="50%"}
 
 Then, [enter and activate your license key](/docs/myinedo/activating-a-license-key) to restore functionality immediately. Note that your Inedo product will display a banner stating that it is only meant for trial purposes; this is merely a cosmetic reminder and your Inedo product will function as a normal license.
-
-## Inedo-Generated Stopgap License Key (Full Featured)
-Inedo-generated stopgap license keys are the best option for organizations that have features that aren't available in the trial edition (i.e. ProGet's feed replication), or that require more users/servers (BuildMaster, Otter) than a trial allows. Obtaining a full stopgap license key can take between 2-3 days to complete.
-
-[Contact Inedo's licensing department](https://inedo.com/company/contact) with your organization's name, current license key, and what full stopgap license key you need.
-
-After receiving your full stopgap license key, you can continue using all the paid features of your Inedo product for up to 30 days.
-
-Once you receive your full license key, [enter it](/docs/myinedo/activating-a-license-key) and begin using your paid license key again. 


### PR DESCRIPTION
Edited the following page:

https://docs.inedo.com/docs/myinedo/stopgap-license-keys

Removed Inedo key section and mentioned functionality of trail key lets you use enterprise features.